### PR TITLE
feat: add options.author

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ publisher.publish('_post/2015-07-17-example-post.md', 'file content').then(funct
 * **force** – whether to replace any pre-existing file no matter what
 * **message** – a custom commit message. Default is `new content`
 * **sha** – the sha of an existing file that one wants to replace
+* **author** – `{name, email}` of the commit author
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ GitHubPublisher.prototype.publish = function (file, content, options) {
 
   const data = {
     message: options.message || 'new content',
+    author: options.author,
     content: this.base64(content)
   };
 

--- a/test/github.spec.js
+++ b/test/github.spec.js
@@ -201,5 +201,31 @@ describe('GitHubPublisher', () => {
         result.should.equal(createdSha);
       });
     });
+
+    it('should allow customizeable commit authors', () => {
+      publisher = new GitHubPublisher(token, user, repo);
+
+      const mock = nock('https://api.github.com/')
+        .put(path, {
+          message: 'foobar2',
+          content: base64,
+          author: {
+            name: 'Clint',
+            email: 'clint@someone.com'
+          }
+        })
+        .reply(201, githubCreationResponse);
+
+      return publisher.publish(file, content, {
+        message: 'foobar2',
+        author: {
+          name: 'Clint',
+          email: 'clint@someone.com'
+        }
+      }).then(result => {
+        mock.done();
+        result.should.equal(createdSha);
+      });
+    });
   });
 });


### PR DESCRIPTION
Add support for `options.author` :

```js
publisher.publish("log-YYMMAA", logContent, {
  message: 'some commit message',
  author: {
    name: 'Clint',
    email: 'clint@someone.com'
  }
})
```